### PR TITLE
Add fused MLP benchmarks and CUDA kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# Fused 4096×4096 MLP Benchmarks
+
+This repository provides three implementations of the following fused computation targeting NVIDIA A100 (SM80) GPUs:
+
+```
+Y = Linear(X, W1)        # 4096 × 4096, no bias
+Y = SiLU(Y)
+Z = Linear(Y, W2)        # 4096 × 4096, no bias
+```
+
+The goal is to compare latency (P50, P99) for:
+
+1. **PyTorch baseline** – stock operations executed sequentially.
+2. **CUTLASS fused kernel** – a custom CUDA extension that keeps data in shared memory and relies on CUTLASS utilities.
+3. **Native fused kernel** – a hand-written CUDA kernel that implements the same tiling strategy without CUTLASS helpers.
+
+## Repository Layout
+
+```
+benchmarks/
+  baseline.py          # PyTorch reference and benchmarking harness
+  benchmark_utils.py   # Latency measurement helpers (P50/P99)
+  extensions.py        # Compiles CUDA extensions via torch.utils.cpp_extension
+  run_all.py           # CLI script to benchmark all implementations
+cpp/
+  common/fused_common.cuh   # Shared tensor validation + math helpers
+  cutlass_fused/             # CUTLASS-based fused kernel + bindings
+  native_fused/              # Native CUDA fused kernel + bindings
+```
+
+## Prerequisites
+
+* CUDA-capable GPU (the kernels are tuned for A100 / SM80 but work on other recent architectures).
+* Python 3.10+
+* PyTorch with CUDA support.
+* CUTLASS v3.5.1 checkout (or newer) available locally.
+* `tabulate` Python package for pretty-printing benchmark tables.
+
+Clone CUTLASS next to the repository or point `CUTLASS_DIR` at an existing checkout:
+
+```bash
+mkdir -p external
+git clone --depth=1 --branch v3.5.1 https://github.com/NVIDIA/cutlass.git external/cutlass
+```
+
+Install Python dependencies:
+
+```bash
+pip install torch tabulate
+```
+
+## Running Benchmarks
+
+Invoke the benchmark driver to compile extensions on-the-fly and collect latency numbers:
+
+```bash
+python -m benchmarks.run_all --device cuda --dtype float16 --warmup 20 --iters 100
+```
+
+Arguments:
+
+* `--device` (default: `cuda` if available) – device to run benchmarks on.
+* `--dtype` (default: `float16`) – choose between `float16`, `float32`, and `bfloat16`.
+* `--warmup` – warmup iterations discarded from measurements.
+* `--iters` – number of timed iterations.
+* `--skip-native` / `--skip-cutlass` – optional flags to skip compiling either extension.
+
+The script prints a Markdown table with P50/P99 latencies and validates that fused kernels match the baseline (max absolute difference).
+
+## Implementation Notes
+
+* Both fused kernels operate on fixed 4096×4096 matrices and use a 64×64 output tile per thread block with 16×16 threads.
+* The CUTLASS variant uses `cutlass::Array` and `cutlass::NumericConverter` helpers to manage per-thread fragments and type conversion while keeping the fused pipeline inside a single kernel launch.
+* The native variant mirrors the tiling strategy using explicit CUDA math.
+* Accumulation occurs in FP32 for float16/bfloat16 inputs.
+
+## Troubleshooting
+
+* Ensure the CUTLASS headers are discoverable. Set `CUTLASS_DIR` or place the repository under `external/cutlass`.
+* Compile time can be significant the first time the extensions build; subsequent runs reuse the cached binaries.
+* To change the targeted GPU architecture, set `TORCH_CUDA_ARCH_LIST` before running `benchmarks.run_all`.

--- a/benchmarks/baseline.py
+++ b/benchmarks/baseline.py
@@ -1,0 +1,50 @@
+"""PyTorch reference implementation for the fused MLP benchmark."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+from .benchmark_utils import LatencyStats, measure_latency
+
+
+@dataclass
+class BaselineResult:
+    latency: LatencyStats
+    output: torch.Tensor
+
+
+def fused_mlp_reference(x: torch.Tensor, w1: torch.Tensor, w2: torch.Tensor) -> torch.Tensor:
+    """Compute the baseline fused MLP using PyTorch ops."""
+
+    y = F.linear(x, w1, bias=None)
+    y = F.silu(y)
+    z = F.linear(y, w2, bias=None)
+    return z
+
+
+def run_baseline(
+    x: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    *,
+    warmup: int = 10,
+    iters: int = 100,
+) -> BaselineResult:
+    """Benchmark the reference fused MLP for the provided tensors."""
+
+    device = x.device
+
+    def op() -> torch.Tensor:
+        return fused_mlp_reference(x, w1, w2)
+
+    latency = measure_latency(op, warmup=warmup, iters=iters, device=device)
+    # Run one final time to return the output tensor for validation purposes.
+    with torch.inference_mode():
+        out = fused_mlp_reference(x, w1, w2)
+    return BaselineResult(latency=latency, output=out)
+
+
+__all__ = ["BaselineResult", "fused_mlp_reference", "run_baseline"]

--- a/benchmarks/benchmark_utils.py
+++ b/benchmarks/benchmark_utils.py
@@ -1,0 +1,121 @@
+"""Utility helpers for benchmarking fused MLP implementations."""
+
+from __future__ import annotations
+
+import statistics
+import time
+from dataclasses import dataclass
+from typing import Callable, List, Sequence
+
+import torch
+
+
+@dataclass
+class LatencyStats:
+    """Simple container tracking latency samples and summary statistics."""
+
+    samples_ms: List[float]
+
+    @property
+    def p50_ms(self) -> float:
+        return statistics.median(self.samples_ms)
+
+    @property
+    def p99_ms(self) -> float:
+        if not self.samples_ms:
+            return float("nan")
+        sorted_samples = sorted(self.samples_ms)
+        index = min(int(round(0.99 * (len(sorted_samples) - 1))), len(sorted_samples) - 1)
+        return sorted_samples[index]
+
+
+def _ensure_inference_context(func: Callable[[], torch.Tensor]) -> Callable[[], torch.Tensor]:
+    def wrapper() -> torch.Tensor:
+        with torch.inference_mode():
+            return func()
+
+    return wrapper
+
+
+def measure_latency(
+    func: Callable[[], torch.Tensor],
+    *,
+    warmup: int = 10,
+    iters: int = 100,
+    device: torch.device | str | None = None,
+) -> LatencyStats:
+    """Measure latency of ``func`` returning :class:`LatencyStats`.
+
+    The returned latencies are recorded in milliseconds. If ``device`` resolves
+    to a CUDA device we rely on CUDA events to collect precise timings,
+    otherwise a CPU wall clock is used.
+    """
+
+    if iters <= 0:
+        raise ValueError("iters must be > 0")
+    if warmup < 0:
+        raise ValueError("warmup must be >= 0")
+
+    resolved_device: torch.device
+    if device is None:
+        resolved_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        resolved_device = torch.device(device)
+
+    wrapped = _ensure_inference_context(func)
+
+    samples: List[float] = []
+
+    if resolved_device.type == "cuda":
+        # Warmup
+        for _ in range(warmup):
+            wrapped()
+        torch.cuda.synchronize(resolved_device)
+
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        for _ in range(iters):
+            start_event.record()
+            wrapped()
+            end_event.record()
+            end_event.synchronize()
+            samples.append(start_event.elapsed_time(end_event))
+
+        torch.cuda.synchronize(resolved_device)
+    else:
+        # CPU path
+        for _ in range(warmup):
+            wrapped()
+
+        for _ in range(iters):
+            start = time.perf_counter()
+            wrapped()
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+            end = time.perf_counter()
+            samples.append((end - start) * 1000.0)
+
+    return LatencyStats(samples)
+
+
+def summarize_results(name_latency_pairs: Sequence[tuple[str, LatencyStats]]) -> str:
+    """Format latency statistics as a Markdown table."""
+
+    try:
+        from tabulate import tabulate
+    except ModuleNotFoundError as exc:  # pragma: no cover - dependency missing at runtime
+        raise RuntimeError(
+            "tabulate is required for pretty printing results. Install it via 'pip install tabulate'."
+        ) from exc
+
+    headers = ["Implementation", "P50 (ms)", "P99 (ms)"]
+    rows = [
+        (
+            name,
+            f"{stats.p50_ms:.3f}" if stats.samples_ms else "n/a",
+            f"{stats.p99_ms:.3f}" if stats.samples_ms else "n/a",
+        )
+        for name, stats in name_latency_pairs
+    ]
+    return tabulate(rows, headers=headers, tablefmt="github")

--- a/benchmarks/extensions.py
+++ b/benchmarks/extensions.py
@@ -1,0 +1,81 @@
+"""Helpers for building/loading fused CUDA extensions."""
+
+from __future__ import annotations
+
+import functools
+import os
+import pathlib
+from typing import Optional
+
+from torch.utils.cpp_extension import load as load_extension
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_CPP_ROOT = _REPO_ROOT / "cpp"
+
+
+def _cuda_arch_flags() -> list[str]:
+    arch_env = os.environ.get("TORCH_CUDA_ARCH_LIST")
+    if arch_env:
+        arches = [arch.strip() for arch in arch_env.split() if arch.strip()]
+        flags = [f"-gencode=arch=compute_{arch},code=sm_{arch}" for arch in arches]
+        if flags:
+            return flags
+    # Default to Ampere / SM80 which matches the target environment (A100).
+    return ["-gencode=arch=compute_80,code=sm_80"]
+
+
+def _load_extension(name: str, sources: list[pathlib.Path], *, extra_include_paths: Optional[list[pathlib.Path]] = None) -> object:
+    include_dirs = [str(_CPP_ROOT / "common")] + [str(path) for path in (extra_include_paths or [])]
+
+    extra_cuda_cflags = ["-O3", "-lineinfo", "--use_fast_math"] + _cuda_arch_flags()
+    extra_cflags = ["-O3", "-std=c++17"]
+
+    return load_extension(
+        name=name,
+        sources=[str(src) for src in sources],
+        extra_include_paths=include_dirs,
+        extra_cflags=extra_cflags,
+        extra_cuda_cflags=extra_cuda_cflags,
+        with_cuda=True,
+        verbose=False,
+    )
+
+
+@functools.lru_cache(maxsize=None)
+def load_native_fused() -> object:
+    """Compile and return the native fused CUDA extension."""
+
+    src_dir = _CPP_ROOT / "native_fused"
+    sources = [src_dir / "binding.cpp", src_dir / "fused_kernel.cu"]
+    return _load_extension("fused_mlp_native", sources)
+
+
+def _resolve_cutlass_dir() -> pathlib.Path:
+    candidates = []
+    env = os.environ.get("CUTLASS_DIR")
+    if env:
+        candidates.append(pathlib.Path(env))
+    candidates.append(_REPO_ROOT / "external" / "cutlass")
+    candidates.append(_REPO_ROOT / "cutlass")
+
+    for path in candidates:
+        if path.exists():
+            return path
+    raise FileNotFoundError(
+        "Unable to locate CUTLASS. Set the CUTLASS_DIR environment variable or clone the library "
+        "into 'external/cutlass'."
+    )
+
+
+@functools.lru_cache(maxsize=None)
+def load_cutlass_fused() -> object:
+    """Compile and return the CUTLASS-based fused CUDA extension."""
+
+    cutlass_dir = _resolve_cutlass_dir()
+    src_dir = _CPP_ROOT / "cutlass_fused"
+    sources = [src_dir / "binding.cpp", src_dir / "fused_kernel.cu"]
+    return _load_extension("fused_mlp_cutlass", sources, extra_include_paths=[cutlass_dir])
+
+
+__all__ = ["load_native_fused", "load_cutlass_fused"]

--- a/benchmarks/run_all.py
+++ b/benchmarks/run_all.py
@@ -1,0 +1,138 @@
+"""Entry point for benchmarking baseline and fused CUDA kernels."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import torch
+
+from .baseline import run_baseline
+from .benchmark_utils import LatencyStats, measure_latency, summarize_results
+from .extensions import load_cutlass_fused, load_native_fused
+
+
+@dataclass
+class BenchmarkOutcome:
+    name: str
+    latency: LatencyStats
+    max_abs_diff: float | None = None
+
+
+def _resolve_device(device_arg: Optional[str]) -> torch.device:
+    if device_arg is None:
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        return torch.device("cpu")
+    return torch.device(device_arg)
+
+
+def _resolve_dtype(dtype_arg: str) -> torch.dtype:
+    mapping = {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }
+    try:
+        return mapping[dtype_arg]
+    except KeyError as exc:  # pragma: no cover - guard rails for CLI usage
+        raise ValueError(f"Unsupported dtype '{dtype_arg}'. Choose from {list(mapping)}") from exc
+
+
+def _allocate_inputs(dtype: torch.dtype, device: torch.device) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    shape = (4096, 4096)
+    generator = torch.Generator(device=device.type) if device.type == "cuda" else torch.Generator()
+    x = torch.randn(shape, device=device, dtype=dtype, generator=generator)
+    w1 = torch.randn(shape, device=device, dtype=dtype, generator=generator)
+    w2 = torch.randn(shape, device=device, dtype=dtype, generator=generator)
+    return x, w1, w2
+
+
+def _benchmark_extension(
+    name: str,
+    forward_fn: Callable[[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor],
+    x: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    *,
+    warmup: int,
+    iters: int,
+    baseline_output: torch.Tensor,
+) -> BenchmarkOutcome:
+    def op() -> torch.Tensor:
+        return forward_fn(x, w1, w2)
+
+    latency = measure_latency(op, warmup=warmup, iters=iters, device=x.device)
+    with torch.inference_mode():
+        out = forward_fn(x, w1, w2)
+    max_abs_diff = (out - baseline_output).abs().max().item()
+    return BenchmarkOutcome(name=name, latency=latency, max_abs_diff=max_abs_diff)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", type=str, default=None, help="Device to benchmark on (default: cuda if available).")
+    parser.add_argument("--dtype", type=str, default="float16", help="Data type: float32|float16|bfloat16")
+    parser.add_argument("--warmup", type=int, default=10, help="Number of warmup iterations before measuring.")
+    parser.add_argument("--iters", type=int, default=50, help="Number of iterations for latency measurement.")
+    parser.add_argument("--skip-cutlass", action="store_true", help="Skip the CUTLASS fused kernel benchmark.")
+    parser.add_argument("--skip-native", action="store_true", help="Skip the native fused kernel benchmark.")
+    args = parser.parse_args()
+
+    device = _resolve_device(args.device)
+    dtype = _resolve_dtype(args.dtype)
+
+    if device.type != "cuda":
+        print("[WARN] CUDA device not available - fused kernels require CUDA for execution.")
+
+    x, w1, w2 = _allocate_inputs(dtype, device)
+
+    baseline_result = run_baseline(x, w1, w2, warmup=args.warmup, iters=args.iters)
+    outcomes: list[BenchmarkOutcome] = [
+        BenchmarkOutcome(name="PyTorch baseline", latency=baseline_result.latency, max_abs_diff=0.0)
+    ]
+
+    if device.type == "cuda" and not args.skip_native:
+        native_module = load_native_fused()
+        outcomes.append(
+            _benchmark_extension(
+                "Native fused kernel",
+                native_module.fused_forward,
+                x,
+                w1,
+                w2,
+                warmup=args.warmup,
+                iters=args.iters,
+                baseline_output=baseline_result.output,
+            )
+        )
+
+    if device.type == "cuda" and not args.skip_cutlass:
+        cutlass_module = load_cutlass_fused()
+        outcomes.append(
+            _benchmark_extension(
+                "CUTLASS fused kernel",
+                cutlass_module.fused_forward,
+                x,
+                w1,
+                w2,
+                warmup=args.warmup,
+                iters=args.iters,
+                baseline_output=baseline_result.output,
+            )
+        )
+
+    table = summarize_results([(outcome.name, outcome.latency) for outcome in outcomes])
+    print(table)
+
+    print("\nVerification (max |diff| vs baseline):")
+    for outcome in outcomes:
+        if outcome.max_abs_diff is None:
+            print(f"  - {outcome.name}: n/a")
+        else:
+            print(f"  - {outcome.name}: {outcome.max_abs_diff:.6f}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/cpp/common/fused_common.cuh
+++ b/cpp/common/fused_common.cuh
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/util/BFloat16.h>
+#include <c10/util/Half.h>
+
+#include <cuda_runtime.h>
+
+namespace fused_mlp {
+
+constexpr int kMatrixDim = 4096;
+
+template <typename T>
+struct AccumulatorType {
+    using type = T;
+};
+
+template <>
+struct AccumulatorType<c10::Half> {
+    using type = float;
+};
+
+template <>
+struct AccumulatorType<c10::BFloat16> {
+    using type = float;
+};
+
+template <typename T>
+struct ScalarConversion {
+    using scalar_t = T;
+
+    __device__ static inline float to_float(T x) {
+        return static_cast<float>(x);
+    }
+
+    __device__ static inline T from_float(float x) {
+        return static_cast<T>(x);
+    }
+};
+
+template <>
+struct ScalarConversion<c10::Half> {
+    using scalar_t = c10::Half;
+
+    __device__ static inline float to_float(c10::Half x) {
+        return static_cast<float>(x);
+    }
+
+    __device__ static inline c10::Half from_float(float x) {
+        return static_cast<c10::Half>(x);
+    }
+};
+
+template <>
+struct ScalarConversion<c10::BFloat16> {
+    using scalar_t = c10::BFloat16;
+
+    __device__ static inline float to_float(c10::BFloat16 x) {
+        return static_cast<float>(x);
+    }
+
+    __device__ static inline c10::BFloat16 from_float(float x) {
+        return static_cast<c10::BFloat16>(x);
+    }
+};
+
+__device__ inline float silu_float(float x) {
+    return x / (1.0f + expf(-x));
+}
+
+template <typename scalar_t>
+__device__ inline scalar_t silu(scalar_t x) {
+    float xf = ScalarConversion<scalar_t>::to_float(x);
+    float yf = silu_float(xf);
+    return ScalarConversion<scalar_t>::from_float(yf);
+}
+
+inline void validate_inputs(const at::Tensor& x, const at::Tensor& w1, const at::Tensor& w2) {
+    TORCH_CHECK(x.dim() == 2, "Input must be rank-2 tensor");
+    TORCH_CHECK(w1.dim() == 2 && w2.dim() == 2, "Weights must be rank-2 tensors");
+
+    TORCH_CHECK(x.size(0) == kMatrixDim && x.size(1) == kMatrixDim, "Input must be 4096x4096");
+    TORCH_CHECK(w1.size(0) == kMatrixDim && w1.size(1) == kMatrixDim, "W1 must be 4096x4096");
+    TORCH_CHECK(w2.size(0) == kMatrixDim && w2.size(1) == kMatrixDim, "W2 must be 4096x4096");
+
+    TORCH_CHECK(x.device().is_cuda(), "Input tensor must reside on CUDA device");
+    TORCH_CHECK(w1.device() == x.device() && w2.device() == x.device(), "All tensors must be on the same device");
+
+    TORCH_CHECK(x.dtype() == w1.dtype() && x.dtype() == w2.dtype(), "All tensors must share dtype");
+}
+
+}  // namespace fused_mlp

--- a/cpp/cutlass_fused/binding.cpp
+++ b/cpp/cutlass_fused/binding.cpp
@@ -1,0 +1,39 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+#include "fused_common.cuh"
+
+namespace fused_mlp {
+void launch_cutlass_fused(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w2,
+    at::Tensor& out,
+    cudaStream_t stream);
+}
+
+namespace {
+
+torch::Tensor fused_forward(torch::Tensor x, torch::Tensor w1, torch::Tensor w2) {
+    fused_mlp::validate_inputs(x, w1, w2);
+
+    at::cuda::CUDAGuard device_guard(x.device());
+
+    auto x_contig = x.contiguous();
+    auto w1_contig = w1.contiguous();
+    auto w2_contig = w2.contiguous();
+
+    auto options = x_contig.options();
+    auto out = torch::empty({x_contig.size(0), w2_contig.size(0)}, options);
+
+    auto stream = at::cuda::getCurrentCUDAStream();
+    fused_mlp::launch_cutlass_fused(x_contig, w1_contig, w2_contig, out, stream.stream());
+
+    return out;
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("fused_forward", &fused_forward, "CUTLASS fused MLP forward pass");
+}

--- a/cpp/cutlass_fused/fused_kernel.cu
+++ b/cpp/cutlass_fused/fused_kernel.cu
@@ -1,0 +1,228 @@
+#include "fused_common.cuh"
+
+#include <cutlass/array.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_conversion.h>
+
+namespace fused_mlp {
+namespace cutlass_impl {
+
+constexpr int BLOCK_M = 64;
+constexpr int BLOCK_N = 64;
+constexpr int TILE_K = 16;
+constexpr int INPUT_CHUNK = 32;
+constexpr int THREADS_X = 16;
+constexpr int THREADS_Y = 16;
+constexpr int THREAD_M = BLOCK_M / THREADS_Y;
+constexpr int THREAD_N = BLOCK_N / THREADS_X;
+constexpr int Z_FRAG_SIZE = THREAD_M * THREAD_N;
+constexpr int Y_FRAG_SIZE = THREAD_M * TILE_K;
+
+static_assert(BLOCK_M % THREADS_Y == 0, "BLOCK_M must be divisible by THREADS_Y");
+static_assert(BLOCK_N % THREADS_X == 0, "BLOCK_N must be divisible by THREADS_X");
+
+template <typename scalar_t>
+__global__ void fused_kernel(
+    const scalar_t* __restrict__ x,
+    const scalar_t* __restrict__ w1,
+    const scalar_t* __restrict__ w2,
+    scalar_t* __restrict__ out,
+    int64_t m,
+    int64_t k,
+    int64_t hidden,
+    int64_t n) {
+    using acc_t = typename AccumulatorType<scalar_t>::type;
+    using ToAccum = cutlass::NumericConverter<acc_t, scalar_t>;
+    using FromAccum = cutlass::NumericConverter<scalar_t, acc_t>;
+
+    __shared__ scalar_t shared_x[BLOCK_M * INPUT_CHUNK];
+    __shared__ scalar_t shared_w1[TILE_K * INPUT_CHUNK];
+    __shared__ scalar_t shared_w2[TILE_K * BLOCK_N];
+
+    const int block_row = blockIdx.y;
+    const int block_col = blockIdx.x;
+
+    const int row_start = block_row * BLOCK_M;
+    const int col_start = block_col * BLOCK_N;
+
+    const int thread_linear = threadIdx.y * blockDim.x + threadIdx.x;
+    const int total_threads = blockDim.x * blockDim.y;
+
+    cutlass::Array<acc_t, Z_FRAG_SIZE> z_frag;
+    for (int idx = 0; idx < Z_FRAG_SIZE; ++idx) {
+        z_frag[idx] = acc_t(0);
+    }
+
+    ToAccum to_accum;
+    FromAccum from_accum;
+
+    for (int hidden_start = 0; hidden_start < hidden; hidden_start += TILE_K) {
+        cutlass::Array<acc_t, Y_FRAG_SIZE> y_frag;
+        for (int idx = 0; idx < Y_FRAG_SIZE; ++idx) {
+            y_frag[idx] = acc_t(0);
+        }
+
+        for (int input_start = 0; input_start < k; input_start += INPUT_CHUNK) {
+            for (int linear_idx = thread_linear; linear_idx < BLOCK_M * INPUT_CHUNK; linear_idx += total_threads) {
+                const int local_row = linear_idx / INPUT_CHUNK;
+                const int local_col = linear_idx % INPUT_CHUNK;
+                const int global_row = row_start + local_row;
+                const int global_col = input_start + local_col;
+
+                scalar_t value = scalar_t(0);
+                if (global_row < m && global_col < k) {
+                    value = x[global_row * k + global_col];
+                }
+                shared_x[local_row * INPUT_CHUNK + local_col] = value;
+            }
+
+            for (int linear_idx = thread_linear; linear_idx < TILE_K * INPUT_CHUNK; linear_idx += total_threads) {
+                const int local_hidden = linear_idx / INPUT_CHUNK;
+                const int local_col = linear_idx % INPUT_CHUNK;
+                const int global_hidden = hidden_start + local_hidden;
+                const int global_col = input_start + local_col;
+
+                scalar_t value = scalar_t(0);
+                if (global_hidden < hidden && global_col < k) {
+                    value = w1[global_hidden * k + global_col];
+                }
+                shared_w1[local_hidden * INPUT_CHUNK + local_col] = value;
+            }
+
+            __syncthreads();
+
+            for (int inner = 0; inner < INPUT_CHUNK; ++inner) {
+                acc_t a_vals[THREAD_M];
+                #pragma unroll
+                for (int i = 0; i < THREAD_M; ++i) {
+                    const int local_row = threadIdx.y * THREAD_M + i;
+                    const int global_row = row_start + local_row;
+                    if (global_row < m) {
+                        const scalar_t a = shared_x[local_row * INPUT_CHUNK + inner];
+                        a_vals[i] = to_accum(a);
+                    } else {
+                        a_vals[i] = acc_t(0);
+                    }
+                }
+
+                #pragma unroll
+                for (int kk = 0; kk < TILE_K; ++kk) {
+                    const scalar_t b_val = shared_w1[kk * INPUT_CHUNK + inner];
+                    const acc_t b = to_accum(b_val);
+                    #pragma unroll
+                    for (int i = 0; i < THREAD_M; ++i) {
+                        y_frag[i * TILE_K + kk] += a_vals[i] * b;
+                    }
+                }
+            }
+
+            __syncthreads();
+        }
+
+        for (int idx = 0; idx < Y_FRAG_SIZE; ++idx) {
+            y_frag[idx] = silu_float(static_cast<float>(y_frag[idx]));
+        }
+
+        for (int linear_idx = thread_linear; linear_idx < TILE_K * BLOCK_N; linear_idx += total_threads) {
+            const int local_hidden = linear_idx / BLOCK_N;
+            const int local_col = linear_idx % BLOCK_N;
+            const int global_hidden = hidden_start + local_hidden;
+            const int global_col = col_start + local_col;
+
+            scalar_t value = scalar_t(0);
+            if (global_hidden < hidden && global_col < n) {
+                value = w2[global_col * hidden + global_hidden];
+            }
+            shared_w2[local_hidden * BLOCK_N + local_col] = value;
+        }
+
+        __syncthreads();
+
+        #pragma unroll
+        for (int kk = 0; kk < TILE_K; ++kk) {
+            cutlass::Array<acc_t, THREAD_N> w_vals;
+            #pragma unroll
+            for (int j = 0; j < THREAD_N; ++j) {
+                const int local_col = threadIdx.x * THREAD_N + j;
+                const int global_col = col_start + local_col;
+                if (global_col < n) {
+                    const scalar_t wv = shared_w2[kk * BLOCK_N + local_col];
+                    w_vals[j] = to_accum(wv);
+                } else {
+                    w_vals[j] = acc_t(0);
+                }
+            }
+
+            #pragma unroll
+            for (int i = 0; i < THREAD_M; ++i) {
+                const acc_t y_val = y_frag[i * TILE_K + kk];
+                #pragma unroll
+                for (int j = 0; j < THREAD_N; ++j) {
+                    z_frag[i * THREAD_N + j] += y_val * w_vals[j];
+                }
+            }
+        }
+
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int i = 0; i < THREAD_M; ++i) {
+        const int local_row = threadIdx.y * THREAD_M + i;
+        const int global_row = row_start + local_row;
+        if (global_row >= m) {
+            continue;
+        }
+        #pragma unroll
+        for (int j = 0; j < THREAD_N; ++j) {
+            const int local_col = threadIdx.x * THREAD_N + j;
+            const int global_col = col_start + local_col;
+            if (global_col >= n) {
+                continue;
+            }
+            const acc_t value = z_frag[i * THREAD_N + j];
+            out[global_row * n + global_col] = from_accum(value);
+        }
+    }
+}
+
+
+template <typename scalar_t>
+void launch_kernel(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w2,
+    at::Tensor& out,
+    cudaStream_t stream) {
+    const dim3 block_dim(THREADS_X, THREADS_Y);
+    const dim3 grid_dim(
+        (out.size(1) + BLOCK_N - 1) / BLOCK_N,
+        (out.size(0) + BLOCK_M - 1) / BLOCK_M);
+
+    fused_kernel<scalar_t><<<grid_dim, block_dim, 0, stream>>>(
+        x.data_ptr<scalar_t>(),
+        w1.data_ptr<scalar_t>(),
+        w2.data_ptr<scalar_t>(),
+        out.data_ptr<scalar_t>(),
+        out.size(0),
+        x.size(1),
+        w1.size(0),
+        out.size(1));
+
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace cutlass_impl
+
+void launch_cutlass_fused(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w2,
+    at::Tensor& out,
+    cudaStream_t stream) {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, x.scalar_type(), "cutlass_fused_kernel", [&] {
+        cutlass_impl::launch_kernel<scalar_t>(x, w1, w2, out, stream);
+    });
+}
+
+}  // namespace fused_mlp

--- a/cpp/native_fused/binding.cpp
+++ b/cpp/native_fused/binding.cpp
@@ -1,0 +1,39 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+#include "fused_common.cuh"
+
+namespace fused_mlp {
+void launch_native_fused(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w2,
+    at::Tensor& out,
+    cudaStream_t stream);
+}
+
+namespace {
+
+torch::Tensor fused_forward(torch::Tensor x, torch::Tensor w1, torch::Tensor w2) {
+    fused_mlp::validate_inputs(x, w1, w2);
+
+    at::cuda::CUDAGuard device_guard(x.device());
+
+    auto x_contig = x.contiguous();
+    auto w1_contig = w1.contiguous();
+    auto w2_contig = w2.contiguous();
+
+    auto options = x_contig.options();
+    auto out = torch::empty({x_contig.size(0), w2_contig.size(0)}, options);
+
+    auto stream = at::cuda::getCurrentCUDAStream();
+    fused_mlp::launch_native_fused(x_contig, w1_contig, w2_contig, out, stream.stream());
+
+    return out;
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("fused_forward", &fused_forward, "Native fused MLP forward pass");
+}

--- a/cpp/native_fused/fused_kernel.cu
+++ b/cpp/native_fused/fused_kernel.cu
@@ -1,0 +1,229 @@
+#include "fused_common.cuh"
+
+namespace fused_mlp {
+namespace native {
+
+constexpr int BLOCK_M = 64;
+constexpr int BLOCK_N = 64;
+constexpr int TILE_K = 16;
+constexpr int INPUT_CHUNK = 32;
+constexpr int THREADS_X = 16;
+constexpr int THREADS_Y = 16;
+constexpr int THREAD_M = BLOCK_M / THREADS_Y;  // 4
+constexpr int THREAD_N = BLOCK_N / THREADS_X;  // 4
+
+static_assert(BLOCK_M % THREADS_Y == 0, "BLOCK_M must be divisible by THREADS_Y");
+static_assert(BLOCK_N % THREADS_X == 0, "BLOCK_N must be divisible by THREADS_X");
+
+template <typename scalar_t>
+__global__ void fused_kernel(
+    const scalar_t* __restrict__ x,
+    const scalar_t* __restrict__ w1,
+    const scalar_t* __restrict__ w2,
+    scalar_t* __restrict__ out,
+    int64_t m,
+    int64_t k,
+    int64_t hidden,
+    int64_t n) {
+    using acc_t = typename AccumulatorType<scalar_t>::type;
+
+    __shared__ scalar_t shared_x[BLOCK_M * INPUT_CHUNK];
+    __shared__ scalar_t shared_w1[TILE_K * INPUT_CHUNK];
+    __shared__ scalar_t shared_w2[TILE_K * BLOCK_N];
+
+    const int block_row = blockIdx.y;
+    const int block_col = blockIdx.x;
+
+    const int row_start = block_row * BLOCK_M;
+    const int col_start = block_col * BLOCK_N;
+
+    const int thread_linear = threadIdx.y * blockDim.x + threadIdx.x;
+    const int total_threads = blockDim.x * blockDim.y;
+
+    acc_t z_frag[THREAD_M][THREAD_N];
+    #pragma unroll
+    for (int i = 0; i < THREAD_M; ++i) {
+        #pragma unroll
+        for (int j = 0; j < THREAD_N; ++j) {
+            z_frag[i][j] = acc_t(0);
+        }
+    }
+
+    for (int hidden_start = 0; hidden_start < hidden; hidden_start += TILE_K) {
+        acc_t y_frag[THREAD_M][TILE_K];
+        #pragma unroll
+        for (int i = 0; i < THREAD_M; ++i) {
+            #pragma unroll
+            for (int j = 0; j < TILE_K; ++j) {
+                y_frag[i][j] = acc_t(0);
+            }
+        }
+
+        for (int input_start = 0; input_start < k; input_start += INPUT_CHUNK) {
+            for (int linear_idx = thread_linear; linear_idx < BLOCK_M * INPUT_CHUNK; linear_idx += total_threads) {
+                const int local_row = linear_idx / INPUT_CHUNK;
+                const int local_col = linear_idx % INPUT_CHUNK;
+                const int global_row = row_start + local_row;
+                const int global_col = input_start + local_col;
+
+                scalar_t value = scalar_t(0);
+                if (global_row < m && global_col < k) {
+                    value = x[global_row * k + global_col];
+                }
+                shared_x[local_row * INPUT_CHUNK + local_col] = value;
+            }
+
+            for (int linear_idx = thread_linear; linear_idx < TILE_K * INPUT_CHUNK; linear_idx += total_threads) {
+                const int local_hidden = linear_idx / INPUT_CHUNK;
+                const int local_col = linear_idx % INPUT_CHUNK;
+                const int global_hidden = hidden_start + local_hidden;
+                const int global_col = input_start + local_col;
+
+                scalar_t value = scalar_t(0);
+                if (global_hidden < hidden && global_col < k) {
+                    value = w1[global_hidden * k + global_col];
+                }
+                shared_w1[local_hidden * INPUT_CHUNK + local_col] = value;
+            }
+
+            __syncthreads();
+
+            for (int inner = 0; inner < INPUT_CHUNK; ++inner) {
+                acc_t a_vals[THREAD_M];
+                #pragma unroll
+                for (int i = 0; i < THREAD_M; ++i) {
+                    const int local_row = threadIdx.y * THREAD_M + i;
+                    const int global_row = row_start + local_row;
+                    if (global_row < m) {
+                        const scalar_t a = shared_x[local_row * INPUT_CHUNK + inner];
+                        a_vals[i] = ScalarConversion<scalar_t>::to_float(a);
+                    } else {
+                        a_vals[i] = acc_t(0);
+                    }
+                }
+
+                #pragma unroll
+                for (int kk = 0; kk < TILE_K; ++kk) {
+                    const scalar_t b_val = shared_w1[kk * INPUT_CHUNK + inner];
+                    const acc_t b = ScalarConversion<scalar_t>::to_float(b_val);
+                    #pragma unroll
+                    for (int i = 0; i < THREAD_M; ++i) {
+                        y_frag[i][kk] += a_vals[i] * b;
+                    }
+                }
+            }
+
+            __syncthreads();
+        }
+
+        #pragma unroll
+        for (int i = 0; i < THREAD_M; ++i) {
+            #pragma unroll
+            for (int kk = 0; kk < TILE_K; ++kk) {
+                y_frag[i][kk] = silu_float(static_cast<float>(y_frag[i][kk]));
+            }
+        }
+
+        for (int linear_idx = thread_linear; linear_idx < TILE_K * BLOCK_N; linear_idx += total_threads) {
+            const int local_hidden = linear_idx / BLOCK_N;
+            const int local_col = linear_idx % BLOCK_N;
+            const int global_hidden = hidden_start + local_hidden;
+            const int global_col = col_start + local_col;
+
+            scalar_t value = scalar_t(0);
+            if (global_hidden < hidden && global_col < n) {
+                value = w2[global_col * hidden + global_hidden];
+            }
+            shared_w2[local_hidden * BLOCK_N + local_col] = value;
+        }
+
+        __syncthreads();
+
+        #pragma unroll
+        for (int kk = 0; kk < TILE_K; ++kk) {
+            acc_t w_vals[THREAD_N];
+            #pragma unroll
+            for (int j = 0; j < THREAD_N; ++j) {
+                const int local_col = threadIdx.x * THREAD_N + j;
+                const int global_col = col_start + local_col;
+                if (global_col < n) {
+                    const scalar_t wv = shared_w2[kk * BLOCK_N + local_col];
+                    w_vals[j] = ScalarConversion<scalar_t>::to_float(wv);
+                } else {
+                    w_vals[j] = acc_t(0);
+                }
+            }
+
+            #pragma unroll
+            for (int i = 0; i < THREAD_M; ++i) {
+                const acc_t y_val = y_frag[i][kk];
+                #pragma unroll
+                for (int j = 0; j < THREAD_N; ++j) {
+                    z_frag[i][j] += y_val * w_vals[j];
+                }
+            }
+        }
+
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int i = 0; i < THREAD_M; ++i) {
+        const int local_row = threadIdx.y * THREAD_M + i;
+        const int global_row = row_start + local_row;
+        if (global_row >= m) {
+            continue;
+        }
+        #pragma unroll
+        for (int j = 0; j < THREAD_N; ++j) {
+            const int local_col = threadIdx.x * THREAD_N + j;
+            const int global_col = col_start + local_col;
+            if (global_col >= n) {
+                continue;
+            }
+            const float value = static_cast<float>(z_frag[i][j]);
+            out[global_row * n + global_col] = ScalarConversion<scalar_t>::from_float(value);
+        }
+    }
+}
+
+
+template <typename scalar_t>
+void launch_kernel(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w2,
+    at::Tensor& out,
+    cudaStream_t stream) {
+    const dim3 block_dim(THREADS_X, THREADS_Y);
+    const dim3 grid_dim(
+        (out.size(1) + BLOCK_N - 1) / BLOCK_N,
+        (out.size(0) + BLOCK_M - 1) / BLOCK_M);
+
+    fused_kernel<scalar_t><<<grid_dim, block_dim, 0, stream>>>(
+        x.data_ptr<scalar_t>(),
+        w1.data_ptr<scalar_t>(),
+        w2.data_ptr<scalar_t>(),
+        out.data_ptr<scalar_t>(),
+        out.size(0),
+        x.size(1),
+        w1.size(0),
+        out.size(1));
+
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace native
+
+void launch_native_fused(
+    const at::Tensor& x,
+    const at::Tensor& w1,
+    const at::Tensor& w2,
+    at::Tensor& out,
+    cudaStream_t stream) {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, x.scalar_type(), "native_fused_kernel", [&] {
+        native::launch_kernel<scalar_t>(x, w1, w2, out, stream);
+    });
+}
+
+}  // namespace fused_mlp


### PR DESCRIPTION
## Summary
- add a PyTorch baseline benchmark harness for the 4096x4096 MLP
- provide CUDA extensions plus loaders for native and CUTLASS fused kernels
- document setup and usage in a README

## Testing
- python -m compileall benchmarks cpp

------
https://chatgpt.com/codex/tasks/task_e_68ca4a0743848330a4c8d38a61d5eb50